### PR TITLE
use PAT to authenticate (for updates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ tests/__pycache__
 /.settings
 /.idea
 /src/punx/data/local
+
+# Microsoft VS Code editor
+launch.json
+settings.json

--- a/src/punx/github_handler.py
+++ b/src/punx/github_handler.py
@@ -108,7 +108,7 @@ class GitHub_Repository_Reference(object):
         self.zip_url = None
         self.last_modified = None
     
-    def connect_repo(self, repo_name=None):
+    def connect_repo(self, repo_name=None, token=None):
         """
         connect with the GitHub repository
         
@@ -117,15 +117,13 @@ class GitHub_Repository_Reference(object):
         """
         repo_name = repo_name or self.appName
         
-        creds = get_BasicAuth_credentials()
-        if creds is None:
+        if token is None:
             gh = github.Github()
             self.repo = gh.get_repo(repo_name)
         else:
-            gh = github.Github(creds['user'], creds['password'])
+            gh = github.Github(token)
             user = gh.get_user(self.orgName)
             self.repo = user.get_repo(repo_name)
-        return creds is not None
     
     def request_info(self, ref=None):
         """

--- a/src/punx/main.py
+++ b/src/punx/main.py
@@ -430,6 +430,13 @@ def parse_command_line_arguments():
         action='store_true', 
         default=False, 
         help='force update (if GitHub available)')
+
+    p_sub.add_argument(
+        '-t', '--token', 
+        action='store_true', 
+        default=None, 
+        help='GitHub personal access token')
+
     # TODO: add_logging_argument(p_sub)
 
 

--- a/src/punx/main.py
+++ b/src/punx/main.py
@@ -272,13 +272,13 @@ def func_update(args):
     cm = cache_manager.CacheManager()
     print(cm.table_of_caches())
 
-    if args.try_to_install_or_update:
+    if args.token is not None:
         grr = github_handler.GitHub_Repository_Reference()
-        grr.connect_repo()
+        grr.connect_repo(token=args.token)
         cm.find_all_file_sets()
         
         for ref in args.file_set_list:
-            _install(cm, grr, ref, force=args.force)
+            _install(cm, grr, ref, force=args.token is None)
         
         print(cm.table_of_caches())
 
@@ -419,12 +419,6 @@ def parse_command_line_arguments():
         nargs='*',
         help=help_text)
 
-    p_sub.add_argument("-i", "--install",
-        action='store_false', 
-        default=True,
-        dest='try_to_install_or_update',
-        help='Do not install (or update) -- default True')
-
     p_sub.add_argument(
         '-f', '--force', 
         action='store_true', 
@@ -433,9 +427,8 @@ def parse_command_line_arguments():
 
     p_sub.add_argument(
         '-t', '--token', 
-        action='store_true', 
         default=None, 
-        help='GitHub personal access token')
+        help='GitHub personal access token (to update the NXDL file sets)')
 
     # TODO: add_logging_argument(p_sub)
 


### PR DESCRIPTION
The GitHub API changed its authentication policies recently and the basic authentication (username and password) is no longer available.  The current policy uses the [Personal Access Token](https://github.com/settings/tokens).  Fixes #120