### PR TITLE
BUG: on update, don't warn about missing env var when token provided by command-line option

### DIFF
--- a/punx/cache_manager.py
+++ b/punx/cache_manager.py
@@ -267,13 +267,13 @@ class CacheManager(singletons.Singleton):
 
     def install_NXDL_file_set(self, grr, user_cache=True, ref=None, force=False):
         """
-        using `ref` as a name, get the se of NXDL files from the NeXus GitHub
+        Using `ref`, get the set of NXDL files from the NeXus GitHub repo.
 
         :param obj grr: instance of :class:`GitHub_Repository_Reference`
         :param bool user_cache: ``True``: use user cache,
                                 `` False``: use source cache (default)
         :param str ref: name to use when requesting from GitHub,
-                        (`master`, commit hash such as `abc1234`,
+                        (`main`, commit hash such as `abc1234`,
                         branch name, release name such as `v3.2`,
                         or tag name)
         :param bool force: update if installed is not the same SHA

--- a/punx/github_handler.py
+++ b/punx/github_handler.py
@@ -113,6 +113,7 @@ class GitHub_Repository_Reference(object):
         self.sha = None
         self.zip_url = None
         self.last_modified = None
+        self.token = None
 
     def connect_repo(self, repo_name=None, token=None):
         """
@@ -124,14 +125,14 @@ class GitHub_Repository_Reference(object):
         """
         repo_name = repo_name or self.appName
 
-        token = get_GitHub_credentials() if token is None else token
+        self.token = get_GitHub_credentials() if token is None else token
 
         # also set the repo attribute
-        gh = github.Github(token)  # token is either None or a str
+        gh = github.Github(self.token)  # token is either None or a str
         user = gh.get_user(self.orgName)
         self.repo = user.get_repo(repo_name)
 
-        return isinstance(token, str)
+        return isinstance(self.token, str)
 
     def request_info(self, ref=None):
         """
@@ -167,20 +168,20 @@ class GitHub_Repository_Reference(object):
         # "disabling warnings about GitHub self-signed https certificates"
         disable_warnings(InsecureRequestWarning)
 
-        token = get_GitHub_credentials()
+        # token = get_GitHub_credentials()
         content = None
         for _retry in range(GITHUB_RETRY_COUNT):  # noqa
             try:
-                if token is None:
+                if self.token is None:
                     content = requests.get(self.zip_url, verify=False)
                 else:
                     content = requests.get(
                         self.zip_url,
-                        headers={"Authorization": f"TOK:{token}"},
+                        headers={"Authorization": f"TOK:{self.token}"},
                         verify=False,
                     )
             except requests.exceptions.ConnectionError as _exc:
-                raise IOError("ConnectionError from " + self.zip_url + "\n" + str(_exc))
+                raise IOError(f"ConnectionError from {self.zip_url}\n{_exc}")
             else:
                 break
 

--- a/punx/main.py
+++ b/punx/main.py
@@ -271,9 +271,19 @@ def func_update(args):
     cm = cache_manager.CacheManager()
     print(cm.table_of_caches())
 
-    if args.token is not None:
+    if args.token is None:
+        token = github_handler.get_GitHub_credentials()
+    else:
+        token = args.token
+
+    if token is None:
+        # TODO: Is it possible to update the cache without a GitHub API token?
+        # Might be possible by downloading a ZIP of the file_set and removing
+        # the unnecessary content.
+        print("GitHub API token is not available.  Will not update cache.")
+    else:
         grr = github_handler.GitHub_Repository_Reference()
-        grr.connect_repo(token=args.token)
+        grr.connect_repo(token=token)
         cm.find_all_file_sets()
 
         for ref in args.file_set_list:

--- a/punx/main.py
+++ b/punx/main.py
@@ -277,7 +277,7 @@ def func_update(args):
         cm.find_all_file_sets()
 
         for ref in args.file_set_list:
-            _install(cm, grr, ref, force=args.token is None)
+            _install(cm, grr, ref, force=True)
 
         print(cm.table_of_caches())
 

--- a/punx/tests/test_nxdl_manager_summary_table.py
+++ b/punx/tests/test_nxdl_manager_summary_table.py
@@ -126,7 +126,7 @@ def test_summary_table():
     """
     cm = cache_manager.CacheManager()
     with pytest.raises(KeyError):
-        cm.select_NXDL_file_set("main")
+        cm.select_NXDL_file_set("no such file_set exists so raises KeyError")
 
     cm.select_NXDL_file_set(FILE_SET)
     assert cm is not None


### PR DESCRIPTION
- FIX #179