### PR TITLE
fix external link bug

### DIFF
--- a/punx/h5tree.py
+++ b/punx/h5tree.py
@@ -158,8 +158,8 @@ class Hdf5TreeView(object):
                         obj, link_info
                     ):  # TODO: is obj the "parent"
                         # When "classref" is defined, then external data is available
-                        s += self._renderSingleAttribute(indentation + "  ", "file", link_info.filename)
-                        s += self._renderSingleAttribute(indentation + "  ", "path", link_info.path)
+                        s += [self._renderSingleAttribute(indentation + "  ", "file", link_info.filename)]
+                        s += [self._renderSingleAttribute(indentation + "  ", "path", link_info.path)]
                 else:
                     msg = (
                         "unidentified %s: %s, %s",


### PR DESCRIPTION
Bug when displaying an HDF5 tree with external links.

Before the fix

```
  @default = "entry"
  entry:NXentry
    @NX_class = "NXentry"
    @default = "data"
    data:NXdata
      @NX_class = "NXdata"
      @axes = "two_theta"
      @signal = "counts"
      @two_theta_indices = [0]
      counts:NX_INT32[31] = [1037, 1318, 1704, '...', 1321]
        @units = "counts"
 
 
 
 
 
 
 
 
@
f
i
l
e
 
=
 
"
e
x
t
e
r
n
a
l
_
c
o
u
n
t
s
.
h
d
f
5
"
 ...
```

After the fix

```
  @default = "entry"
  entry:NXentry
    @NX_class = "NXentry"
    @default = "data"
    data:NXdata
      @NX_class = "NXdata"
      @axes = "two_theta"
      @signal = "counts"
      @two_theta_indices = [0]
      counts:NX_INT32[31] = [1037, 1318, 1704, '...', 1321]
        @units = "counts"
        @file = "external_counts.hdf5"
        @path = "/entry/instrument/detector/counts"
      two_theta:NX_FLOAT64[31] = [17.92608, 17.92591, 17.92575, '...', 17.92108]
        @units = "degrees"
        @file = "external_angles.hdf5"
        @path = "/angles"
    instrument:NXinstrument
      @NX_class = "NXinstrument"
      @file = "external_counts.hdf5"
      @path = "/entry/instrument"
      detector:NXdetector
        @NX_class = "NXdetector"
        counts:NX_INT32[31] = [1037, 1318, 1704, '...', 1321]
          @units = "counts"
        two_theta:NX_FLOAT64[31] = [17.92608, 17.92591, 17.92575, '...', 17.92108]
          @units = "degrees"
          @file = "external_angles.hdf5"
          @path = "/angles"
```