### PR TITLE
the value of an attribute is not always a string

### DIFF
--- a/punx/validations/hdf5_group_items_in_base_class.py
+++ b/punx/validations/hdf5_group_items_in_base_class.py
@@ -112,7 +112,7 @@ def verify_group_attributes(validator, v_item, base_class):
             test_name = "value of @" + k
             status = finding.TODO
             c = "TODO: need to validate"
-            c += ": @" + k + " = " + v
+            c += ": @" + k + " = " + str(v)
             validator.record_finding(a_item, test_name, status, c)
 
 


### PR DESCRIPTION
For example  [/NXdata/DATA@axes-attribute](https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata-data-axes-attribute).

```
@axes=["time", ".", "."]
```