### PR TITLE
Validations: Fix problems with h5py generated files

### DIFF
--- a/punx/validations/application_definition.py
+++ b/punx/validations/application_definition.py
@@ -8,6 +8,8 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import numpy
+
 from .. import finding
 from .. import utils
 from ..validate import ValidationItem
@@ -17,7 +19,10 @@ def verify(validator, v_item):
     """
     Verify items specified in application definition are present in HDF5 data file
     """
-    ad_name = str(utils.decode_byte_string(v_item.h5_object["definition"][()]))
+    item = v_item.h5_object["definition"][()]
+    if isinstance(item, (list, tuple, numpy.ndarray)):
+        item = item[0]
+    ad_name = str(utils.decode_byte_string(item))
     key = "NeXus application definition"
 
     ad = validator.manager.classes.get(ad_name)
@@ -58,7 +63,10 @@ def verify(validator, v_item):
         if len(spec.enumerations) > 0:
             found = False
             for enum in spec.enumerations:
-                found = enum == utils.decode_byte_string(h5_obj[()])
+                obj = h5_obj[()]
+                if isinstance(obj, (list, tuple, numpy.ndarray)):
+                    obj = obj[0]
+                found = enum == utils.decode_byte_string(obj)
                 if found:
                     break
             msg = "%s:%s" % (ad_name, field)


### PR DESCRIPTION
It seems the that the h5py doesn't create scalar string values. For the most applications it seems not to be a problem, but the validation did not handle this case, which leads to problems during the validation.

In case the expected value is a collection type (list, tuple, numpy.ndarray) the first entry will taken as the string.